### PR TITLE
fix: Move scripts to ./bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A monitor solution for jailbroken iOS devices. The core goal of this project is to make sure a specific iOS application is constantly running without needed to use Single App Mode (SAM) or Guided Access Mode (GAM).
 
-A `setup` script is included to help with initial configuration of a jailbroken device.
+A `./bin/setup` script is included to help with initial configuration of a jailbroken device.
 
 Lastly, in the future I would like to include a way to handle updates for the various components.
 
@@ -80,7 +80,9 @@ It is assumed you know your way around a command line. All commands are run on y
 1. In a third terminal window run:
 
    ```sh
-   ./setup
+   ./bin/setup
+   # If you want to setup passwordless ssh then pass the argument with the path to your key
+   ./bin/setup -s ~/.ssh/main.pub
    ```
 
 1. Assuming everything worked correctly your phone should be properly configured.

--- a/bin/package
+++ b/bin/package
@@ -1,4 +1,8 @@
 #!/bin/zsh
+# Make sure this is always ran from the parent directory path.
+cd "$(dirname "$0")"
+cd ..
+
 # Ugly hack. This should really be excluded by dm.pl but ¯\_(ツ)_/¯
 /usr/bin/find . -name '.DS_Store' -type f -prune -exec rm -rf '{}' +
 DEB_VERSION=$(grep -i "^Version:" ./src/DEBIAN/control | cut -d' ' -f2 -)

--- a/bin/setup
+++ b/bin/setup
@@ -1,11 +1,27 @@
 #!/bin/zsh
 ############################################
-# Version 0.0.2
+# Version 0.0.3
 ############################################
+SCRIPT_NAME=$(basename $0)
+# Make sure this is always ran from the parent directory path.
+cd "$(dirname "$0")"
+cd ..
 
-## Setup ssh passwordless auth (Optional). Allow this via cli argument?
-#ssh root@localhost -p 2222 'mkdir ~/.ssh'
-#scp -P 2222 ~/.ssh/main.pub root@localhost:~/.ssh/authorized_keys
+while getopts 's:' OPTION; do
+  case "$OPTION" in
+    s)
+      SSH_KEY_PATH="$OPTARG"
+      echo Setting up ssh passwordless auth with: "$SSH_KEY_PATH"
+      ssh root@localhost -p 2222 'mkdir ~/.ssh'
+      scp -P 2222 "$SSH_KEY_PATH" root@localhost:~/.ssh/authorized_keys
+      ;;
+    ?)
+      echo "Script usage: "$SCRIPT_NAME" [-s path/to/ssh_public_key]" >&2
+      exit 1
+      ;;
+  esac
+done
+shift "$(($OPTIND -1))"
 
 echo Installing Pogo
 ideviceinstaller -i ./pogo.ipa


### PR DESCRIPTION
- All scripts live under ./bin
- Ability to include your own ssh key via `-s /path/to/key.pub`