### PR TITLE
Use DCM for request version.txt and deb files

### DIFF
--- a/tools/dmon.m
+++ b/tools/dmon.m
@@ -130,7 +130,7 @@ int killall(NSString *appName) {
     NSLog(@"dmon: Stopping appName: %@", appName);
     int stop_pid;
     char command[100]; // Make it large enough.
-    sprintf(command, "/var/root/install/killall %s 2>/dev/null", [appName UTF8String]);
+    sprintf(command, "killall %s 2>/dev/null", [appName UTF8String]);
     FILE *stop_pid_cmd = popen(command, "r");
     fscanf(stop_pid_cmd, "%d", &stop_pid);
     pclose(stop_pid_cmd);


### PR DESCRIPTION
Fixes #10 

- Use bearer token in order to authenticate to DCM
- Download version.txt file from DCM
- Download deb files from DCM

I set this as default, probably should be optional

* Requires https://github.com/versx/DeviceConfigManager/pull/103