### PR TITLE
fix: Support Windows CRLF line endings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,7 @@ export SYSROOT = $(THEOS)/sdks/sdks-master/iPhoneOS14.5.sdk
 THEOS_DEVICE_IP = iphone
 
 PACKAGE_NAME = com.github.clburlison.dmon
-PACKAGE_VERSION = 0.1.0
+PACKAGE_VERSION = 0.1.1
 HASH1 = $(shell shasum -a256 "packages/com.github.clburlison.dmon_$(PACKAGE_VERSION)_iphoneos-arm.deb" | cut -d " " -f1)
 HASH2 = $(shell md5 "packages/com.github.clburlison.dmon_$(PACKAGE_VERSION)_iphoneos-arm.deb" | cut -d " " -f4)
 

--- a/src/dmon.m
+++ b/src/dmon.m
@@ -110,8 +110,9 @@ NSMutableDictionary * parseKeyValueFileAtPath(NSString *filePath) {
         NSLog(@"dmon: Error reading file: %@", error);
         return nil;
     }
-    
-    NSArray *lines = [fileContents componentsSeparatedByString:@"\n"];
+
+    NSCharacterSet *lineSeparatorSet = [NSCharacterSet characterSetWithCharactersInString:@"\n\r"];
+    NSArray *lines = [fileContents componentsSeparatedByCharactersInSet:lineSeparatorSet];
     for (NSString *line in lines) {
         NSArray *parts = [line componentsSeparatedByString:@": "];
         if (parts.count == 2) {


### PR DESCRIPTION
Report from NPlumb. Can easily test line endings
with `od -c f filename.txt`